### PR TITLE
When rendering component use a clone of component_properties hash

### DIFF
--- a/app/views/mountain_view/styleguide/show.html.erb
+++ b/app/views/mountain_view/styleguide/show.html.erb
@@ -13,7 +13,7 @@
       <% @component.component_stubs.each_with_index do |component_properties, index| %>
           <div class="mv-component">
             <div class="mv-component__item">
-              <%= render_component @component.name, component_properties %>
+              <%= render_component @component.name, component_properties.clone %>
             </div>
             <div class="mv-component__description">
               <h2><%= @component.title %> <%= index + 1 %></h2>


### PR DESCRIPTION
When a component is rendered in the styleguide show view, if for some reason the component_properties hash is modified somewhere in the template the description in the view includes the modified version of the hash.

By using a clone of the properties hash when rendering the component the view correctly reflects only the parameters passed into the component.

Real usage example: A date_input component that renders text_input with the same properties with the additon of { inputmask: 'date' } such as:
```
<% properties[:inputmask] = 'date' %>
<%= render_component('text_input', properties) %>          
```