### PR TITLE
Tests: fix warnings and circular dependency.

### DIFF
--- a/app/assets/javascripts/mountain_view.js.erb
+++ b/app/assets/javascripts/mountain_view.js.erb
@@ -1,4 +1,4 @@
-<% if Dir.exists?(MountainView.configuration.components_path) %>
+<% if Dir.exist?(MountainView.configuration.components_path) %>
   <% depend_on MountainView.configuration.components_path.to_s %>
   <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir

--- a/app/assets/stylesheets/mountain_view.css.erb
+++ b/app/assets/stylesheets/mountain_view.css.erb
@@ -1,7 +1,7 @@
 <% MountainView.configuration.included_stylesheets.each do |included_stylesheet| %>
   <%= require_asset included_stylesheet %>
 <% end %>
-<% if Dir.exists?(MountainView.configuration.components_path) %>
+<% if Dir.exist?(MountainView.configuration.components_path) %>
   <% depend_on MountainView.configuration.components_path.to_s %>
   <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -1,5 +1,4 @@
 require "rails"
-require "mountain_view"
 require "mountain_view/component"
 
 module MountainView

--- a/test/helpers/mountain_view/component_helper_test.rb
+++ b/test/helpers/mountain_view/component_helper_test.rb
@@ -7,6 +7,6 @@ class MountainView::ComponentHelperTest < ActionView::TestCase
     expected = /Pepe/
 
     assert_match expected, rendered
-    assert_match /href=\"\/products\/1\"/, rendered
+    assert_match(/href=\"\/products\/1\"/, rendered)
   end
 end

--- a/test/helpers/mountain_view/component_helper_test.rb
+++ b/test/helpers/mountain_view/component_helper_test.rb
@@ -7,6 +7,6 @@ class MountainView::ComponentHelperTest < ActionView::TestCase
     expected = /Pepe/
 
     assert_match expected, rendered
-    assert_match(/href=\"\/products\/1\"/, rendered)
+    assert_match %r(href=\"\/products\/1\"), rendered
   end
 end


### PR DESCRIPTION
fixed some warnings i got when running the tests with `ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]`.

please check whether removing the circular dependency is fine.