### PR TITLE
Fix respond_to? signature

### DIFF
--- a/app/helpers/mountain_view/application_helper.rb
+++ b/app/helpers/mountain_view/application_helper.rb
@@ -12,9 +12,9 @@ module MountainView
       end
     end
 
-    def respond_to?(method)
+    def respond_to?(method, include_all = false)
       if method.to_s.end_with?("_path") || method.to_s.end_with?("_url")
-        if main_app.respond_to?(method)
+        if main_app.respond_to?(method, include_all)
           true
         else
           super


### PR DESCRIPTION
While developing a Rails 4.2 application, I got warnings like this:

```
/usr/home/nilsding/Projects/myapp/app/views/header/_login.haml:7: warning: #<Class:0x000008115ccdd0>#respond_to?(:respond_to_missing?) is old fashion which takes only one parameter
/usr/home/nilsding/.rvm/gems/ruby-2.3.1@myapp/gems/mountain_view-0.9.0/app/helpers/mountain_view/application_helper.rb:15: warning: respond_to? is defined here
```

This commit silences the warning by adding another optional parameter to the method's signature.