### PR TITLE
Allowing override of the styleguide_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ Visit the **<a href="https://mountain-view.herokuapp.com/mountain_view/styleguid
 
 ![mountain_view](https://cloud.githubusercontent.com/assets/623766/7099771/5b06d8da-dfd4-11e4-8558-1b7f026f28ad.gif)
 
+### Custom Routes
+
+To override the path used within the mountain_view engine, set the `styleguide_path` option.
+
+```ruby
+#config/initializers/mountain_view.rb
+
+MountainView.configure do |config|
+  config.styleguide_path = "my-style-guide"
+end
+```
+
 ## Contributing
 
 See the [contributing guide](./CONTRIBUTING.md).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 MountainView::Engine.routes.draw do
   root to: "styleguide#index"
 
-  resources :styleguide, only: [:index, :show]
+  resources :styleguide, only: [:index, :show], path: MountainView.configuration.styleguide_path
 end

--- a/lib/mountain_view/configuration.rb
+++ b/lib/mountain_view/configuration.rb
@@ -2,6 +2,7 @@ module MountainView
   class Configuration
     attr_accessor :included_stylesheets
     attr_reader :components_path
+    attr_reader :styleguide_path
 
     def initialize
       @included_stylesheets = []
@@ -9,6 +10,10 @@ module MountainView
 
     def components_path=(path)
       @components_path = Pathname.new(path)
+    end
+
+    def styleguide_path=(path)
+      @styleguide_path = path
     end
   end
 end

--- a/lib/mountain_view/configuration.rb
+++ b/lib/mountain_view/configuration.rb
@@ -1,8 +1,8 @@
 module MountainView
   class Configuration
     attr_accessor :included_stylesheets
+    attr_accessor :styleguide_path
     attr_reader :components_path
-    attr_reader :styleguide_path
 
     def initialize
       @included_stylesheets = []
@@ -10,10 +10,6 @@ module MountainView
 
     def components_path=(path)
       @components_path = Pathname.new(path)
-    end
-
-    def styleguide_path=(path)
-      @styleguide_path = path
     end
   end
 end

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -11,7 +11,7 @@ class MountedEngineTest < ActionDispatch::IntegrationTest
 
   test "Custom path can be applied to styleguide resource" do
     styleguide_path = MountainView.configuration.styleguide_path
-    
+
     # Set the new path
     MountainView.configuration.styleguide_path = "style-guide"
     Rails.application.reload_routes!

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -1,0 +1,6 @@
+class MountedEngineTest < ActionDispatch::IntegrationTest
+  test 'Has been mounuted successfully' do
+    get '/mountain_view'
+    assert_response :success
+  end
+end

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -3,4 +3,24 @@ class MountedEngineTest < ActionDispatch::IntegrationTest
     get "/mountain_view"
     assert_response :success
   end
+
+  test "Has the styleguide route" do
+    get "/mountain_view/styleguide"
+    assert_response :success
+  end
+
+  test "Custom path can be applied to styleguide resource" do
+    styleguide_path = MountainView.configuration.styleguide_path
+    
+    # Set the new path
+    MountainView.configuration.styleguide_path = "style-guide"
+    Rails.application.reload_routes!
+
+    get "/mountain_view/style-guide"
+    assert_response :success
+
+    # Reset back to original
+    MountainView.configuration.styleguide_path = styleguide_path
+    Rails.application.reload_routes!
+  end
 end

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -1,6 +1,6 @@
 class MountedEngineTest < ActionDispatch::IntegrationTest
-  test 'Has been mounuted successfully' do
-    get '/mountain_view'
+  test "Has been mounted successfully" do
+    get "/mountain_view"
     assert_response :success
   end
 end

--- a/test/mountain_view/configuration_test.rb
+++ b/test/mountain_view/configuration_test.rb
@@ -5,10 +5,21 @@ class MountainViewConfigurationTest < ActiveSupport::TestCase
     assert_equal MountainView::Configuration.new.included_stylesheets, []
   end
 
+  test "default value for styleguide_path is nil" do
+    assert_nil MountainView::Configuration.new.styleguide_path
+  end
+
   test "set custom included_stylesheets" do
     config = MountainView::Configuration.new
     config.included_stylesheets = ["global", "fonts"]
 
     assert_equal config.included_stylesheets, ["global", "fonts"]
+  end
+
+  test "set custom styleguide_path" do
+    config = MountainView::Configuration.new
+    config.styleguide_path = "style-guide"
+
+    assert_equal config.styleguide_path, "style-guide"
   end
 end


### PR DESCRIPTION
This'll allows end users to userride the path used by the
`MountainView::Engine.routes`