### PR TITLE
Fixing DEPRECATION WARNING: `config.static_cache_control`

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -39,7 +39,7 @@ module Dummy
     config.eager_load = false
 
     # Configure static asset server for tests with Cache-Control for performance.
-    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+    # config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
     config.assets.enabled = true
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -39,7 +39,7 @@ module Dummy
     config.eager_load = false
 
     # Configure static asset server for tests with Cache-Control for performance.
-    config.static_cache_control = 'public, max-age=3600'
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
     config.assets.enabled = true
 


### PR DESCRIPTION
Swapped out for `config.public_file_server.headers = { 'Cache-Control'
=> 'public, max-age=3600' }` instead.