### PR TITLE
Hiding warning: method redefined

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
+  t.warning = false
 end
 
 


### PR DESCRIPTION
```
mountain_view/test/mountain_view/presenter_test.rb:7:
warning: method redefined; discarding old title
mountain_view/lib/mountain_view/presenter.rb:55:
warning: previous definition of title was here
```

It's inherited so these warnings are irrelevant.