### PR TITLE
Customize styleguide main page

### DIFF
--- a/app/assets/stylesheets/mountain_view/styleguide.css
+++ b/app/assets/stylesheets/mountain_view/styleguide.css
@@ -23,7 +23,7 @@ body{
     color: white;
     font-size: 20px;
 }
-a.mv-header__logo, a.mv-header__logo:visited{
+.mv-header__logo a, .mv-header__logo a:visited{
     color: white;
     text-decoration: none;
 }

--- a/app/assets/stylesheets/mountain_view/styleguide.css
+++ b/app/assets/stylesheets/mountain_view/styleguide.css
@@ -19,9 +19,13 @@ body{
   padding: 20px;
 }
 .mv-header__logo{
-  font-weight: bold;
-  color: white;
-  font-size: 20px;
+    font-weight: bold;
+    color: white;
+    font-size: 20px;
+}
+a.mv-header__logo, a.mv-header__logo:visited{
+    color: white;
+    text-decoration: none;
 }
 
 /* FlEX WRAPPER */

--- a/app/views/layouts/mountain_view.html.erb
+++ b/app/views/layouts/mountain_view.html.erb
@@ -9,7 +9,7 @@
 </head>
 <body>
   <div class="mv-header">
-    <div class="mv-header__logo">STYLEGUIDE</div>
+    <div class="mv-header__logo"><a href="/mountain_view">STYLEGUIDE</a></div>
   </div>
   <div class="mv-flex-wrapper">
     <div class="mv-sidebar">

--- a/app/views/mountain_view/_styleguide_intro.html.erb
+++ b/app/views/mountain_view/_styleguide_intro.html.erb
@@ -5,5 +5,6 @@
   Select one of the components from the side to view its examples and documentation.
   <br />
   <br />
-  To replace the content on this page, add a folder mountain_view in your views and create a partial `_styleguide_intro.html.erb` or `_styleguide_intro.html.haml` whichever you prefer.
+  To replace the content on this page, add a folder mountain_view in your views and create a partial
+  <code class="language-ruby">_styleguide_intro.html.erb</code> or <code class="language-ruby">_styleguide_intro.html.haml</code> whichever you prefer.
 </div>

--- a/app/views/mountain_view/_styleguide_intro.html.erb
+++ b/app/views/mountain_view/_styleguide_intro.html.erb
@@ -1,0 +1,9 @@
+<div class="mv-main__header">
+  <h1>Styleguide</h1>
+</div>
+<div class="mv-main__description">
+  Select one of the components from the side to view its examples and documentation.
+  <br />
+  <br />
+  To replace the content on this page, add a folder mountain_view in your views and create a partial `_styleguide_intro.html.erb` or `_styleguide_intro.html.haml` whichever you prefer.
+</div>

--- a/app/views/mountain_view/styleguide/index.html.erb
+++ b/app/views/mountain_view/styleguide/index.html.erb
@@ -1,12 +1,10 @@
-<div class="mv-main__header">
-  <h1>Styleguide</h1>
-</div>
 
 <% if mv_components.any? %>
-  <div class="mv-main__description">
-    Select one of the components from the side to view its examples and documentation.
-  </div>
+  <%= render 'mountain_view/styleguide_intro'  %>
 <% else %>
+  <div class="mv-main__header">
+    <h1>Styleguide</h1>
+  </div>
   <div class="mv-hint">
     <h2><span>Hint:</span>You haven't created any components yet</h2>
     <ul>


### PR DESCRIPTION
Created a partial for the style guide home page and included instructions on how to replace it in the content of the partial in the text for the partial.

I have forked mountain_view_demo and updated the mountain_view gem to run this branch in order to test the changes.  

This is the first of several changes referenced in #70