### PR TITLE
Set up Rubocop

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+rubocop:
+  version: 0.59.2
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,73 @@
+AllCops:
+  Exclude:
+    - 'test/dummy/**/*'
+  TargetRubyVersion: 2.2
+
+Layout/DotPosition:
+  Exclude:
+    - 'test/**/*'
+
+Lint/AmbiguousRegexpLiteral:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'test/**/*'
+    - '*.gemspec'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/LineLength:
+  Exclude:
+    - '*.gemspec'
+    - 'test/**/*'
+    - 'lib/generators/**/*'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'test/**/*'
+
+Style/Alias:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'test/**/*'
+
+Style/Documentation:
+  Exclude:
+    - 'app/**/*'
+    - 'test/**/*'
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Exclude:
+    - 'test/**/*'
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+  Exclude:
+    - 'test/**/*'
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Exclude:
+    - 'test/**/*'
+
+Style/WordArray:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,5 @@ gem "rails", rails
 
 # To use debugger
 # gem 'debugger'
+
+gem "rubocop", "0.59.2" # Fixed on this because of HoundCI

--- a/Rakefile
+++ b/Rakefile
@@ -1,33 +1,29 @@
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'MountainView'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_dir = "rdoc"
+  rdoc.title    = "MountainView"
+  rdoc.options << "--line-numbers"
+  rdoc.rdoc_files.include("README.rdoc")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
-
-
-
 
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.libs << "lib"
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
   t.verbose = false
   t.warning = false
 end
-
 
 task default: :test

--- a/app/helpers/mountain_view/styleguide_helper.rb
+++ b/app/helpers/mountain_view/styleguide_helper.rb
@@ -1,7 +1,7 @@
 module MountainView
   module StyleguideHelper
     def method_missing(method, *args, &block)
-      if method.to_s.end_with?("_path") || method.to_s.end_with?("_url")
+      if method.to_s.end_with?("_path", "_url")
         if main_app.respond_to?(method)
           main_app.send(method, *args)
         else
@@ -13,7 +13,7 @@ module MountainView
     end
 
     def respond_to?(method, include_all = false)
-      if method.to_s.end_with?("_path") || method.to_s.end_with?("_url")
+      if method.to_s.end_with?("_path", "_url")
         if main_app.respond_to?(method, include_all)
           true
         else
@@ -22,6 +22,10 @@ module MountainView
       else
         super
       end
+    end
+
+    def respond_to_missing?(method, include_all = false)
+      respond_to?(method, include_all)
     end
 
     def prettify_word(word)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ MountainView::Engine.routes.draw do
         as: "extra_pages"
   end
 
-  resources :styleguide, only: [:index, :show], path: MountainView.configuration.styleguide_path
+  resources :styleguide, only: [:index, :show],
+                         path: MountainView.configuration.styleguide_path
   extra_routes if MountainView.configuration.extra_pages.any?
 end

--- a/lib/generators/mountain_view/extra_pages_generator.rb
+++ b/lib/generators/mountain_view/extra_pages_generator.rb
@@ -12,6 +12,7 @@ module MountainView
         extra_pages.each do |page|
           file_name = "#{views_folder}/#{page}.html.#{template_engine}"
           next if File.exist?(file_name)
+
           create_file file_name
         end
       end

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -1,6 +1,7 @@
 require "rails"
 
 module MountainView
+  # :nodoc:
   class Engine < ::Rails::Engine
     isolate_namespace MountainView
 
@@ -16,14 +17,14 @@ module MountainView
       app.config.autoload_paths += Dir[component_paths]
     end
 
-    initializer "mountain_view.assets" do |app|
+    initializer "mountain_view.assets" do |_app|
       Rails.application.config.assets.paths <<
         MountainView.configuration.components_path
-      Rails.application.config.assets.precompile += %w( mountain_view/styleguide.css
-                                                        mountain_view/styleguide.js )
+      Rails.application.config.assets.precompile +=
+        %w[mountain_view/styleguide.css mountain_view/styleguide.js]
     end
 
-    initializer "mountain_view.append_view_paths" do |app|
+    initializer "mountain_view.append_view_paths" do |_app|
       ActiveSupport.on_load :action_controller do
         append_view_path MountainView.configuration.components_path
       end

--- a/lib/mountain_view/presenter.rb
+++ b/lib/mountain_view/presenter.rb
@@ -10,10 +10,10 @@ module MountainView
       @properties = default_properties.deep_merge(properties)
     end
 
-    def render(context, &block)
+    def render(context)
       context.extend ViewContext
       context.inject_component_context self
-      properties[:yield] ||= yield
+      properties[:yield] ||= yield if block_given?
       context.render partial, partial: partial
     end
 
@@ -53,6 +53,7 @@ module MountainView
       def define_property_methods(names = [])
         names.each do |name|
           next if method_defined?(name)
+
           define_method name do
             properties[name.to_sym]
           end
@@ -60,6 +61,7 @@ module MountainView
       end
     end
 
+    # :nodoc:
     module ViewContext
       attr_reader :_component
       delegate :properties, to: :_component
@@ -70,6 +72,7 @@ module MountainView
         methods = component.public_methods(false) - protected_methods
         methods.each do |meth|
           next if self.class.method_defined?(meth)
+
           self.class.delegate meth, to: :_component
         end
       end

--- a/mountain_view.gemspec
+++ b/mountain_view.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "mountain_view/version"

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ComponentGeneratorTest < Rails::Generators::TestCase
   tests MountainView::Generators::ComponentGenerator
 
-  destination File.expand_path("../../tmp", __FILE__)
+  destination File.expand_path('../tmp', __dir__)
   setup :prepare_destination
 
   test "Assert all files are properly created" do
@@ -12,7 +12,7 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     Rails.application.config.app_generators.stylesheet_engine nil
     Rails.application.config.app_generators.javascript_engine nil
 
-    run_generator %w( widget )
+    run_generator %w(widget)
 
     assert_file "app/components/widget/_widget.html.erb"
     assert_file "app/components/widget/widget.css"
@@ -25,7 +25,7 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     Rails.application.config.app_generators.stylesheet_engine :scss
     Rails.application.config.app_generators.javascript_engine :coffee
 
-    run_generator %w( widget )
+    run_generator %w(widget)
 
     assert_file "app/components/widget/_widget.html.haml"
     assert_file "app/components/widget/widget.scss"

--- a/test/generators/extra_pages_generator_test.rb
+++ b/test/generators/extra_pages_generator_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class ExtraPagesGeneratorTest < Rails::Generators::TestCase
   tests MountainView::Generators::ExtraPagesGenerator
 
-  destination File.expand_path("../../tmp", __FILE__)
+  destination File.expand_path('../tmp', __dir__)
   setup :prepare_destination
 
   test "Assert all views and controller are created" do

--- a/test/mountain_view/component_test.rb
+++ b/test/mountain_view/component_test.rb
@@ -21,11 +21,12 @@ class MountainViewComponentTest < ActiveSupport::TestCase
         stubs:
           [
             {
-              id:  1,
+              id: 1,
               title: "20 Mountains you didn't know they even existed",
               subtitle: "Buzzfeed title"
             },
-            { id: 2,
+            {
+              id: 2,
               title: "You won't believe what happened to this man at Aspen"
             }
           ]

--- a/test/mountain_view_test.rb
+++ b/test/mountain_view_test.rb
@@ -75,6 +75,6 @@ class MountainViewTest < ActionDispatch::IntegrationTest
   private
 
   def clean_sprockets_cache
-    FileUtils.rm_rf File.expand_path("../dummy/tmp",  __FILE__)
+    FileUtils.rm_rf File.expand_path('dummy/tmp', __dir__)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require File.expand_path("dummy/config/environment.rb", __dir__)
 require "rails/test_help"
 
 Rails.backtrace_cleaner.remove_silencers!
@@ -11,7 +11,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.method_defined?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
 end
 # for generators
 require "rails/generators/test_case"


### PR DESCRIPTION
- Add `rubocop` to gemfile.
- Add `.rubocop.yml`
- Add `.hound.yml`
- Autofix all rules.

`Style/Documentation` rule is still failing for most `lib/*` modules. I'll update that in another PR.