### PR TITLE
Logo link & customization of main page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,4 @@ gem "rails", rails
 # gem 'debugger'
 
 gem "rubocop", "0.59.2" # Fixed on this because of HoundCI
-gem "tzinfo-data",   :platforms => [:mingw, :x64_mingw, :mswin]
+gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin]

--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,4 @@ gem "rails", rails
 # gem 'debugger'
 
 gem "rubocop", "0.59.2" # Fixed on this because of HoundCI
+gem "tzinfo-data",   :platforms => [:mingw, :x64_mingw, :mswin]

--- a/README.md
+++ b/README.md
@@ -187,35 +187,35 @@ A style guide will be automatically generated. This style guide never falls behi
 
 #### Setting up the style guide
 1) Add the following line to your `routes.rb` file. `/mountain_view` can be any path you want. 
-    ```ruby
-    mount MountainView::Engine => "/mountain_view", as: "mv_style_guide"
-    ```
-    
-    Note: Adding `as: :mv_style_guide` is needed to establish a consistent name for the style guide to provide a link to the main page.
+```ruby
+mount MountainView::Engine => "/mountain_view", as: "mv_style_guide"
+```
+
+Note: Adding `as: :mv_style_guide` is needed to establish a consistent name for the style guide to provide a link to the main page.
 
 2) Create stubs for your components. These stubs will be the examples in the style guide.
 
-    E.g: `app/components/card/card.yml`
-    
-    ```yml
-        -
-          :title: "Aspen Snowmass"
-          :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
-          :link: "http://google.com"
-          :image_url: "http://i.imgur.com/QzuIJTo.jpg"
-          :data:
-          -
-            :title: "Elevation"
-            :number: '7879ft'
-          -
-            :title: "Depth"
-            :number: '71"'
-        -
-          :title: "Sunset on the Mountain"
-          :description: "Three major ranges of the Alps – the Northern Calcareous Alps, Central Alps, and Southern Calcareous Alps – run west to east through Austria. The Central Alps, which consist largely of a granite base, are the largest and highest ranges in Austria."
-          :link: "http://google.com"
-    
-    ```
+E.g: `app/components/card/card.yml`
+
+```yml
+    -
+      :title: "Aspen Snowmass"
+      :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
+      :link: "http://google.com"
+      :image_url: "http://i.imgur.com/QzuIJTo.jpg"
+      :data:
+      -
+        :title: "Elevation"
+        :number: '7879ft'
+      -
+        :title: "Depth"
+        :number: '71"'
+    -
+      :title: "Sunset on the Mountain"
+      :description: "Three major ranges of the Alps – the Northern Calcareous Alps, Central Alps, and Southern Calcareous Alps – run west to east through Austria. The Central Alps, which consist largely of a granite base, are the largest and highest ranges in Austria."
+      :link: "http://google.com"
+
+```
 3) Visit `http://localhost:3000/mountain_view/styleguide`
 
 #### Example Style Guide

--- a/README.md
+++ b/README.md
@@ -186,33 +186,37 @@ rails generate mountain_view:extra_pages
 A style guide will be automatically generated. This style guide never falls behind and it reflects your components in their latest version.
 
 #### Setting up the style guide
-1) Add the following line to your `routes.rb` file.
-```ruby
-mount MountainView::Engine => "/mountain_view"
-```
+1) Add the following line to your `routes.rb` file. `/mountain_view` can be any path you want. 
+    ```ruby
+    mount MountainView::Engine => "/mountain_view", as: mv_style_guide
+    ```
+    
+    Note: Adding `as: :mv_style_guide` is needed to establish a consistent name for the style guide to provide a link to the main page.
+
 2) Create stubs for your components. These stubs will be the examples in the style guide.
 
-E.g: `app/components/card/card.yml`
-```yml
--
-  :title: "Aspen Snowmass"
-  :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
-  :link: "http://google.com"
-  :image_url: "http://i.imgur.com/QzuIJTo.jpg"
-  :data:
-  -
-    :title: "Elevation"
-    :number: '7879ft'
-  -
-    :title: "Depth"
-    :number: '71"'
--
-  :title: "Sunset on the Mountain"
-  :description: "Three major ranges of the Alps – the Northern Calcareous Alps, Central Alps, and Southern Calcareous Alps – run west to east through Austria. The Central Alps, which consist largely of a granite base, are the largest and highest ranges in Austria."
-  :link: "http://google.com"
-
-```
-3) Vist `http://localhost:3000/mountain_view/styleguide`
+    E.g: `app/components/card/card.yml`
+    
+    ```yml
+        -
+          :title: "Aspen Snowmass"
+          :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
+          :link: "http://google.com"
+          :image_url: "http://i.imgur.com/QzuIJTo.jpg"
+          :data:
+          -
+            :title: "Elevation"
+            :number: '7879ft'
+          -
+            :title: "Depth"
+            :number: '71"'
+        -
+          :title: "Sunset on the Mountain"
+          :description: "Three major ranges of the Alps – the Northern Calcareous Alps, Central Alps, and Southern Calcareous Alps – run west to east through Austria. The Central Alps, which consist largely of a granite base, are the largest and highest ranges in Austria."
+          :link: "http://google.com"
+    
+    ```
+3) Visit `http://localhost:3000/mountain_view/styleguide`
 
 #### Example Style Guide
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ A style guide will be automatically generated. This style guide never falls behi
 #### Setting up the style guide
 1) Add the following line to your `routes.rb` file. `/mountain_view` can be any path you want. 
     ```ruby
-    mount MountainView::Engine => "/mountain_view", as: mv_style_guide
+    mount MountainView::Engine => "/mountain_view", as: "mv_style_guide"
     ```
     
     Note: Adding `as: :mv_style_guide` is needed to establish a consistent name for the style guide to provide a link to the main page.

--- a/app/assets/stylesheets/mountain_view/styleguide.css
+++ b/app/assets/stylesheets/mountain_view/styleguide.css
@@ -24,6 +24,11 @@ body{
   font-size: 20px;
 }
 
+.mv-header__logo a, .mv-header__logo a:visited{
+    color: white;
+    text-decoration: none;
+}
+
 /* FlEX WRAPPER */
 
 .mv-flex-wrapper{

--- a/app/views/layouts/mountain_view.html.erb
+++ b/app/views/layouts/mountain_view.html.erb
@@ -10,7 +10,7 @@
 <body>
   <div class="mv-header">
     <div class="mv-header__logo">
-      <% if respond_to? :mv_style_guide %>
+      <% if respond_to? mv_style_guide %>
         <%= link_to t('mountain_view.layout.styleguide_title'), mv_style_guide.root_url%>
       <% else %>
         <%= t('mountain_view.layout.styleguide_title') %>

--- a/app/views/layouts/mountain_view.html.erb
+++ b/app/views/layouts/mountain_view.html.erb
@@ -10,7 +10,7 @@
 <body>
   <div class="mv-header">
     <div class="mv-header__logo">
-      <% if respond_to? mv_style_guide %>
+      <% if Rails.application.routes.url_helpers.respond_to?("mv_style_guide_path") %>
         <%= link_to t('mountain_view.layout.styleguide_title'), mv_style_guide.root_url%>
       <% else %>
         <%= t('mountain_view.layout.styleguide_title') %>

--- a/app/views/layouts/mountain_view.html.erb
+++ b/app/views/layouts/mountain_view.html.erb
@@ -10,7 +10,7 @@
 <body>
   <div class="mv-header">
     <div class="mv-header__logo">
-      <% if respond_to? mv_style_guide %>
+      <% if respond_to? :mv_style_guide %>
         <%= link_to t('mountain_view.layout.styleguide_title'), mv_style_guide.root_url%>
       <% else %>
         <%= t('mountain_view.layout.styleguide_title') %>

--- a/app/views/layouts/mountain_view.html.erb
+++ b/app/views/layouts/mountain_view.html.erb
@@ -9,7 +9,13 @@
 </head>
 <body>
   <div class="mv-header">
-    <div class="mv-header__logo"><%= t('mountain_view.layout.styleguide_title') %></div>
+    <div class="mv-header__logo">
+      <% if respond_to? mv_style_guide %>
+        <%= link_to t('mountain_view.layout.styleguide_title'), mv_style_guide.root_url%>
+      <% else %>
+        <%= t('mountain_view.layout.styleguide_title') %>
+      <% end %>
+    </div>
   </div>
   <div class="mv-flex-wrapper">
     <div class="mv-sidebar">

--- a/app/views/mountain_view/styleguide/_main_page_content.html.erb
+++ b/app/views/mountain_view/styleguide/_main_page_content.html.erb
@@ -1,0 +1,8 @@
+<div class="mv-main__header">
+  <h1><%= t('.mountain_view.layout.styleguide_title') %></h1>
+</div>
+
+<div class="mv-main__description">
+  <%= t('mountain_view.index.description_html') %>
+</div>
+

--- a/app/views/mountain_view/styleguide/index.html.erb
+++ b/app/views/mountain_view/styleguide/index.html.erb
@@ -1,12 +1,10 @@
-<div class="mv-main__header">
-  <h1><%= t('.mountain_view.layout.styleguide_title') %></h1>
-</div>
-
 <% if mv_components.any? %>
-  <div class="mv-main__description">
-    <%= t('mountain_view.index.description') %>
-  </div>
+  <%= render 'mountain_view/styleguide/main_page_content'  %>
 <% else %>
+  <div class="mv-main__header">
+    <h1><%= t('.mountain_view.layout.styleguide_title') %></h1>
+  </div>
+
   <div class="mv-hint">
     <h2><%= t('mountain_view.index.hint_component_html') %></h2>
     <ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,13 @@ en:
       hint_stub_creation_html: <span>Hint:</span>To see your component make sure you've created stubs
       tip_stub_creation_html: 'You should write stub examples here:'
     index:
-      description: Select one of the components from the side to view its examples and documentation.
+      description_html:
+        <p>Select one of the components from the side to view its examples and documentation.</p>
+        <br />
+        <br />
+        <p>To replace the content on this page, add the directory `app/views/mountain_view` in your application,
+        and create a partial named <code class="language-ruby">_styleguide_intro.html.erb</code> or
+        <code class="language-ruby">_styleguide_intro.html.haml</code> whichever you prefer.</p>
       hint_component_html: <span>Hint:</span>You haven't created any components yet
       tip_first_component_html: 'You can generate your first component by running:'
       tip_second_component_html: 'Or manually create the following files:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,8 +15,7 @@ en:
         <br />
         <br />
         <p>To replace the content on this page, add the directory `app/views/mountain_view` in your application,
-        and create a partial named <code class="language-ruby">_styleguide_intro.html.erb</code> or
-        <code class="language-ruby">_styleguide_intro.html.haml</code> whichever you prefer.</p>
+        and create a partial named <code class="language-ruby">_main_page_content.html.erb</code> (or haml or slim, etc).</p>
       hint_component_html: <span>Hint:</span>You haven't created any components yet
       tip_first_component_html: 'You can generate your first component by running:'
       tip_second_component_html: 'Or manually create the following files:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,8 +14,8 @@ en:
         <p>Select one of the components from the side to view its examples and documentation.</p>
         <br />
         <br />
-        <p>To replace the content on this page, add the directory `app/views/mountain_view` in your application,
-        and create a partial named <code class="language-ruby">_main_page_content.html.erb</code> (or haml, slim, etc).</p>
+        <p>To replace the content on this page, add the directory <code>app/views/mountain_view</code> in your application,
+        and create a partial named <code>_main_page_content.html.erb</code> (or haml, slim, etc).</p>
       hint_component_html: <span>Hint:</span>You haven't created any components yet
       tip_first_component_html: 'You can generate your first component by running:'
       tip_second_component_html: 'Or manually create the following files:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
         <br />
         <br />
         <p>To replace the content on this page, add the directory `app/views/mountain_view` in your application,
-        and create a partial named <code class="language-ruby">_main_page_content.html.erb</code> (or haml or slim, etc).</p>
+        and create a partial named <code class="language-ruby">_main_page_content.html.erb</code> (or haml, slim, etc).</p>
       hint_component_html: <span>Hint:</span>You haven't created any components yet
       tip_first_component_html: 'You can generate your first component by running:'
       tip_second_component_html: 'Or manually create the following files:'


### PR DESCRIPTION
Setup the Logo so it will link back to the main page.

Make the content that displays once components have been created into a partial so it is easier to replace that main page with custom content for the main page of the living style guide.

Added gem `tzinfo-data` for windows

Note: this should include all the changes requested in the previous pull request.