### PR TITLE
Use partial and content_for to wrap components in style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ To customize the styleguide, override the style guide layout by adding `mountain
 
 ### Custom meta data for stub examples
 
-You can customize the title, description for each example in the stub, as well as the classes that surround the stub example.  In order to override the default title, add a `title` key to the `mv_stub_meta` hash.  Additional special keys include `description` which will add a description under the title for a given example and `classes` which will add classes for a specific example. 
+You can customize the title, description for each example in the stub, as well as the classes that surround the stub example.  In order to override the default title, add a `title` key to the `mv_stub_meta` hash.  Additional special keys include `description` which will add a description under the title for a given example, `classes` which will add classes for a specific example, and `partial` which will allow ou to embed the component in a partial (see below for details). 
 
 E.g: `app/components/card/card.yml`
 ```yml
@@ -256,6 +256,7 @@ E.g: `app/components/card/card.yml`
         :title: "Specific Example"
         :description: "Instructions for use case or other UX considerations"
         :classes: "black-background"
+        :partial: "card/card_styleguide_partial.html.erb"
       :title: "Aspen Snowmass"
       :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
       :link: "http://google.com"
@@ -268,7 +269,11 @@ E.g: `app/components/card/card.yml`
         :title: "Depth"
         :number: '71"'
 ```
+### Wrapping Components in the Style Guide
 
+Sometimes you may want to wrap extra content around the component in the style guide.  For example, you may want to include a form tag around a custom form component without including the form tag in the component itself. You can do this by adding the key `partial` in the `mv_stub_meta`.
+
+To include the component in the partial, you reference `<%= content_for :"#{mv_content_for_name}" %>`
 
 ## Improving performance
 Rendering a large amount of partials in a request can lead to a performance bottleneck, usually this is caused by the parsing and rendering of template code such as ERB or HAML.

--- a/app/views/mountain_view/styleguide/show.html.erb
+++ b/app/views/mountain_view/styleguide/show.html.erb
@@ -14,7 +14,15 @@
         <h2><%= component_stub.meta_title(@component.title, index) %></h2>
         <div class="mv-component">
           <div class="mv-component__item <%= component_stub.meta_classes %>">
-            <%= render_component @component.name, component_stub.properties.clone %>
+            <% if component_stub.meta_partial.blank? %>
+              <%= render_component @component.name, component_stub.properties.clone %>
+            <% else %>
+              <% content_for_name = "mv_#{@component.name}_#{index}" %>
+              <% content_for :"#{content_for_name}" do %>
+                <%= render_component @component.name, component_stub.properties.clone %>
+              <% end %>
+              <% render component_stub.meta_partial, mv_content_for_name: content_for_name  %>
+            <% end %>
           </div>
           <div class="mv-component__description">
             <h3><%= t('mountain_view.show.instruction_heading') %></h3>

--- a/app/views/mountain_view/styleguide/show.html.erb
+++ b/app/views/mountain_view/styleguide/show.html.erb
@@ -18,10 +18,9 @@
               <%= render_component @component.name, component_stub.properties.clone %>
             <% else %>
               <% content_for_name = "mv_#{@component.name}_#{index}" %>
-              <% content_for :"#{content_for_name}" do %>
-                <%= render_component @component.name, component_stub.properties.clone %>
-              <% end %>
-              <% render component_stub.meta_partial, mv_content_for_name: content_for_name  %>
+              <% content_for :"#{content_for_name}",
+                             render_component(@component.name, component_stub.properties.clone) %>
+              <%= render component_stub.meta_partial, mv_content_for_name: content_for_name  %>
             <% end %>
           </div>
           <div class="mv-component__description">

--- a/lib/mountain_view/stub.rb
+++ b/lib/mountain_view/stub.rb
@@ -25,5 +25,9 @@ module MountainView
     def meta_classes
       @meta[:classes]
     end
+
+    def meta_partial
+      @meta[:partial]
+    end
   end
 end

--- a/test/dummy/app/components/header/_test_partial.html.erb
+++ b/test/dummy/app/components/header/_test_partial.html.erb
@@ -1,3 +1,4 @@
-<div class="test_partial">
+<div class="test_partial" style="background-color: pink">
+  Custom Partial around style use
   <%= content_for :"#{mv_content_for_name}" %>
 </div>

--- a/test/dummy/app/components/header/_test_partial.html.erb
+++ b/test/dummy/app/components/header/_test_partial.html.erb
@@ -1,0 +1,3 @@
+<div class="test_partial">
+  <%= content_for :"#{mv_content_for_name}" %>
+</div>

--- a/test/dummy/app/components/header/header.yml
+++ b/test/dummy/app/components/header/header.yml
@@ -5,6 +5,7 @@
       :title: "Specific Example"
       :description: "Instructions for use case and UX considerations"
       :classes: "black-background"
+      :partial: "header/test_partial.html.erb"
     :id: 1
     :title: "20 Mountains you didn't know they even existed"
     :subtitle: "Buzzfeed title"

--- a/test/mountain_view/stub_test.rb
+++ b/test/mountain_view/stub_test.rb
@@ -31,6 +31,15 @@ class MountainViewStubTest < ActiveSupport::TestCase
                'nil not set for stub meta without classes'
   end
 
+  def test_meta_partial
+    test_object = stub_to_test
+    assert_equal header_stub_meta[:stubs][0][:mv_stub_meta][:partial],
+                 test_object[0].meta_partial,
+                 'Stub Partial not found'
+    assert_nil test_object[1].meta_partial,
+               'nil not set for stub meta without partial'
+  end
+
   def test_properties
     test_object = stub_to_test
     assert_equal header_stub_meta[:stubs][0].except(:mv_stub_meta),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,8 @@ def header_stub_meta
         mv_stub_meta: {
           title: "Specific Example",
           description: "Instructions for use case and UX considerations",
-          classes: "black-background"
+          classes: "black-background",
+          partial: "header/test_partial.html.erb"
         },
         id: 1,
         title: "20 Mountains you didn't know they even existed",


### PR DESCRIPTION
Added the ability to have a partial in the meta.  If partial exists, the component will be added to content_for with a name mv_#{component_name}_#{index} and the partial will be rendered instead of the component.  

To include the component in the partial, you reference `<%= content_for :"#{mv_content_for_name}" %>`