### PR TITLE
Add an option to disable automatically adding assets to the asset pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ Would output the following in your view:
 ### Assets
 You can require all the components CSS and JS automatically by requiring `mountain_view` in your main JS and CSS files.
 
+If you do not want to have rails compile the assets so you can handle them with another method such as Webpacker
+you can skip the asset configuration by setting `skip_assets` eg:
+
+```ruby
+#config/initializers/mountain_view.rb
+
+MountainView.configure do |config|
+  config.skip_assets = true
+end
+
+
 ### Global Stylesheets
 In case you want to add global stylesheets (e.g. reset, bootstrap, a grid system, etc) to your Mountain View components you can do it by calling them with an initializer
 

--- a/lib/mountain_view/configuration.rb
+++ b/lib/mountain_view/configuration.rb
@@ -3,6 +3,7 @@ module MountainView
     attr_accessor :included_stylesheets
     attr_accessor :styleguide_path
     attr_accessor :extra_pages
+    attr_accessor :skip_assets
     attr_reader :components_path
 
     def initialize

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -18,10 +18,12 @@ module MountainView
     end
 
     initializer "mountain_view.assets" do |_app|
-      Rails.application.config.assets.paths <<
-        MountainView.configuration.components_path
-      Rails.application.config.assets.precompile +=
-        %w[mountain_view/styleguide.css mountain_view/styleguide.js]
+      unless MountainView.configuration.skip_assets
+        Rails.application.config.assets.paths <<
+          MountainView.configuration.components_path
+        Rails.application.config.assets.precompile +=
+          %w[mountain_view/styleguide.css mountain_view/styleguide.js]
+      end
     end
 
     initializer "mountain_view.append_view_paths" do |_app|

--- a/test/mountain_view/configuration_test.rb
+++ b/test/mountain_view/configuration_test.rb
@@ -22,4 +22,11 @@ class MountainViewConfigurationTest < ActiveSupport::TestCase
 
     assert_equal config.styleguide_path, "style-guide"
   end
+
+  test "set skip_assets option" do
+    config = MountainView::Configuration.new
+    config.skip_assets = true
+
+    assert config.skip_assets
+  end
 end


### PR DESCRIPTION
Allows projects which do not use the rails asset pipeline, such as those using webpacker to behave more predictably by skipping the initializer step that configures the assets. 

Behaves normally without the config option, so existing users won't notice any change in behaviour.